### PR TITLE
Fix generic type when saving irrigation events

### DIFF
--- a/src/main/java/com/dkolovos/smart/farming/core/application/service/irrigation/InMemoryIrrigationSessionManager.java
+++ b/src/main/java/com/dkolovos/smart/farming/core/application/service/irrigation/InMemoryIrrigationSessionManager.java
@@ -42,7 +42,7 @@ public class InMemoryIrrigationSessionManager implements IrrigationSessionPort {
         Instant end = Instant.now();
         IrrigationEvent event = new IrrigationEvent(zoneId, start, end, Duration.ZERO, "User Id");
         
-        Result result = repository.saveIrrigationEvent(event);
+        Result<Void> result = repository.saveIrrigationEvent(event);
         
         if(result.isSuccess()){
             return Result.success(new IrrigationSessionResult(zoneId, start, end));


### PR DESCRIPTION
## Summary
- use generic `Result<Void>` when saving irrigation events

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d3e56a6483299987a0e7d09dc482