### PR TITLE
Fix infrastructure package name

### DIFF
--- a/src/main/java/com/dkolovos/smart/farming/core/infrastructure/db/local/LocalCropStatusRepositoryImpl.java
+++ b/src/main/java/com/dkolovos/smart/farming/core/infrastructure/db/local/LocalCropStatusRepositoryImpl.java
@@ -2,7 +2,7 @@
  * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
  * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
  */
-package com.dkolovos.smart.farming.core.infastructure.db.local;
+package com.dkolovos.smart.farming.core.infrastructure.db.local;
 
 import com.dkolovos.smart.farming.core.application.usecase.Result;
 import com.dkolovos.smart.farming.core.domain.data.crop.CropStatus;

--- a/src/main/java/com/dkolovos/smart/farming/core/infrastructure/db/local/LocalDiseaseAlertRepositoryImpl.java
+++ b/src/main/java/com/dkolovos/smart/farming/core/infrastructure/db/local/LocalDiseaseAlertRepositoryImpl.java
@@ -2,7 +2,7 @@
  * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
  * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
  */
-package com.dkolovos.smart.farming.core.infastructure.db.local;
+package com.dkolovos.smart.farming.core.infrastructure.db.local;
 
 import com.dkolovos.smart.farming.core.application.usecase.Result;
 import com.dkolovos.smart.farming.core.domain.data.crop.DiseaseAlert;

--- a/src/main/java/com/dkolovos/smart/farming/core/infrastructure/db/local/LocalFlowRateRepositoryImpl.java
+++ b/src/main/java/com/dkolovos/smart/farming/core/infrastructure/db/local/LocalFlowRateRepositoryImpl.java
@@ -2,7 +2,7 @@
  * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
  * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
  */
-package com.dkolovos.smart.farming.core.infastructure.db.local;
+package com.dkolovos.smart.farming.core.infrastructure.db.local;
 
 import com.dkolovos.smart.farming.core.application.usecase.Result;
 import com.dkolovos.smart.farming.core.domain.data.irrigation.FlowRateReading;

--- a/src/main/java/com/dkolovos/smart/farming/core/infrastructure/db/local/LocalIrrigationEventRepositoryImpl.java
+++ b/src/main/java/com/dkolovos/smart/farming/core/infrastructure/db/local/LocalIrrigationEventRepositoryImpl.java
@@ -2,7 +2,7 @@
  * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
  * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
  */
-package com.dkolovos.smart.farming.core.infastructure.db.local;
+package com.dkolovos.smart.farming.core.infrastructure.db.local;
 
 import com.dkolovos.smart.farming.core.application.usecase.Result;
 import com.dkolovos.smart.farming.core.domain.data.irrigation.IrrigationEvent;

--- a/src/main/java/com/dkolovos/smart/farming/core/infrastructure/db/local/LocalPlantHealthRepositoryImpl.java
+++ b/src/main/java/com/dkolovos/smart/farming/core/infrastructure/db/local/LocalPlantHealthRepositoryImpl.java
@@ -2,7 +2,7 @@
  * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
  * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
  */
-package com.dkolovos.smart.farming.core.infastructure.db.local;
+package com.dkolovos.smart.farming.core.infrastructure.db.local;
 
 import com.dkolovos.smart.farming.core.application.usecase.Result;
 import com.dkolovos.smart.farming.core.domain.data.crop.PlantHealth;

--- a/src/main/java/com/dkolovos/smart/farming/core/infrastructure/db/local/LocalSensoReadingRepositoryImpl.java
+++ b/src/main/java/com/dkolovos/smart/farming/core/infrastructure/db/local/LocalSensoReadingRepositoryImpl.java
@@ -2,7 +2,7 @@
  * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
  * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Interface.java to edit this template
  */
-package com.dkolovos.smart.farming.core.infastructure.db.local;
+package com.dkolovos.smart.farming.core.infrastructure.db.local;
 
 import com.dkolovos.smart.farming.core.application.usecase.Result;
 import com.dkolovos.smart.farming.core.domain.data.sensors.SensorReading;


### PR DESCRIPTION
## Summary
- rename `infastructure` directories to `infrastructure`
- update package declarations accordingly

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d3d5831c832989cf56813ea7e3c0